### PR TITLE
Raw items endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ rbenv versions
 </details>
 
 ## Endpoints
-
+|[Champions](#champions)|Origin Class Types|[Raw Items](#raw_items)|Recipes|
 ### Champions
 
 #### Champions Index
@@ -316,120 +316,197 @@ HTTP/1.1 200 OK
         "id": "42",
         "type": "champions",
         "attributes": {
-            "data": {
-                "id": 42,
-                "name": "Swain, the Noxian Grand General",
-                "champion_thumbnail": "https://ddragon.leagueoflegends.com/cdn/9.13.1/img/champion/Swain.png",
-                "cost": 5,
-                "health": [
-                    850,
-                    1530,
-                    3060
-                ],
-                "dmg": 65,
-                "armor": 25,
-                "mr": 20,
-                "atk_spd": 0.65,
-                "range": "■■□□",
-                "ability_thumbnail": "https://raw.communitydragon.org/latest/game/assets/characters/swain/hud/icons2d/swain_r.png",
-                "ability_info": {
-                    "title": "Demonflare",
-                    "attributes": [
-                        {
-                            "healpertick": [
-                                50,
-                                90,
-                                130
-                            ],
-                            "damagepertick": [
-                                50,
-                                100,
-                                150
-                            ],
-                            "soulflaredamage": [
-                                300,
-                                600,
-                                900
-                            ],
-                            "transformduration": 6
-                        }
+            "id": 42,
+            "name": "Swain, the Noxian Grand General",
+            "champion_thumbnail": "https://ddragon.leagueoflegends.com/cdn/9.14.1/img/champion/Swain.png",
+            "cost": 5,
+            "health": [
+                850,
+                1530,
+                3060
+            ],
+            "dmg": 65,
+            "armor": 25,
+            "mr": 20,
+            "atk_spd": 0.65,
+            "range": "■■□□",
+            "ability_thumbnail": "https://raw.communitydragon.org/latest/game/assets/characters/swain/hud/icons2d/swain_r.png",
+            "ability_name": " Demonflare",
+            "ability_info": "Active: Transforms for 6 seconds, dealing 50 / 100 / 150 magic damage to all nearby enemies with each tick while healing for 50 / 90 / 130 health with each tick. At the end of his transformation, sends out a burst of energy dealing 300 / 600 / 900 magic damage to nearby enemies.",
+            "model_img": "https://i.imgur.com/SNB9NHk.png",
+            "origin_class_types": [
+                {
+                    "id": 9,
+                    "name": "Shapeshifter",
+                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Shapeshifter.png",
+                    "summary": "Shapeshifters gain bonus maximum Health when they transform.",
+                    "tier_info": [
+                        " (3)  Shapeshifters gain 100% Bonus Maximum Health"
                     ],
-                    "descrption": "Swain transforms, draining health from all nearby enemies. At the end of his transformation, Swain sends out a burst of energy dealing damage to nearby enemies"
+                    "tiers": [
+                        3
+                    ],
+                    "created_at": "2019-07-21T04:27:22.528Z",
+                    "updated_at": "2019-07-21T04:27:22.528Z"
                 },
-                "model_img": null,
-                "created_at": "2019-07-18T20:59:30.796Z",
-                "updated_at": "2019-07-18T20:59:30.796Z"
-            },
-            "origin_class_type": {
-                "data": [
-                    {
-                        "id": "9",
-                        "type": "origin_class_type",
-                        "attributes": {
-                            "data": {
-                                "id": 9,
-                                "name": "Shapeshifter",
-                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Shapeshifter.png",
-                                "summary": "Shapeshifters gain bonus maximum Health when they transform.",
-                                "tier_info": [
-                                    " (3)  Shapeshifters gain 100% Bonus Maximum Health"
-                                ],
-                                "tiers": [
-                                    3
-                                ],
-                                "created_at": "2019-07-18T20:59:30.240Z",
-                                "updated_at": "2019-07-18T20:59:30.240Z"
-                            }
-                        }
-                    },
-                    {
-                        "id": "11",
-                        "type": "origin_class_type",
-                        "attributes": {
-                            "data": {
-                                "id": 11,
-                                "name": "Demon",
-                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Demon.png",
-                                "summary": "Attacks from Demons have a chance on hit to burn all of an enemy's mana and deal that much as true damage.",
-                                "tier_info": [
-                                    " (2)  Demons have a 40% Chance on Hit to Mana Burn",
-                                    " (4)  Demons have a 60% Chance on Hit to Mana Burn",
-                                    " (6)  Demons have a 80% Chance on Hit to Mana Burn"
-                                ],
-                                "tiers": [
-                                    2,
-                                    4,
-                                    6
-                                ],
-                                "created_at": "2019-07-18T20:59:30.244Z",
-                                "updated_at": "2019-07-18T20:59:30.244Z"
-                            }
-                        }
-                    },
-                    {
-                        "id": "16",
-                        "type": "origin_class_type",
-                        "attributes": {
-                            "data": {
-                                "id": 16,
-                                "name": "Imperial",
-                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Imperial.png",
-                                "summary": "Imperials deal double damage.",
-                                "tier_info": [
-                                    " (2)  1 Random Imperial deals double damage",
-                                    " (4)  All Imperials deal double damage"
-                                ],
-                                "tiers": [
-                                    2,
-                                    4
-                                ],
-                                "created_at": "2019-07-18T20:59:30.257Z",
-                                "updated_at": "2019-07-18T20:59:30.257Z"
-                            }
-                        }
-                    }
-                ]
+                {
+                    "id": 11,
+                    "name": "Demon",
+                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Demon.png",
+                    "summary": "Attacks from Demons have a chance on hit to burn all of an enemy's mana and deal that much as true damage.",
+                    "tier_info": [
+                        " (2)  Demons have a 40% Chance on Hit to Mana Burn",
+                        " (4)  Demons have a 60% Chance on Hit to Mana Burn",
+                        " (6)  Demons have a 80% Chance on Hit to Mana Burn"
+                    ],
+                    "tiers": [
+                        2,
+                        4,
+                        6
+                    ],
+                    "created_at": "2019-07-21T04:27:22.535Z",
+                    "updated_at": "2019-07-21T04:27:22.535Z"
+                },
+                {
+                    "id": 16,
+                    "name": "Imperial",
+                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Imperial.png",
+                    "summary": "Imperials deal double damage.",
+                    "tier_info": [
+                        " (2)  1 Random Imperial deals double damage",
+                        " (4)  All Imperials deal double damage"
+                    ],
+                    "tiers": [
+                        2,
+                        4
+                    ],
+                    "created_at": "2019-07-21T04:27:22.565Z",
+                    "updated_at": "2019-07-21T04:27:22.565Z"
+                }
+            ]
+        }
+    }
+}
+```
+
+</details>
+
+<details><summary>Failed Responses</summary>
+
+##### Other
+
+```http
+HTTP/1.1 500 Internal Server Error
+```
+
+###### Body
+
+```js
+{"error": "Internal Server Error"}
+```
+
+</details>
+
+---
+### Raw Items
+
+#### Raw Items Index
+
+Returns all raw_items currently in the database
+
+##### Request
+
+```http
+GET /api/v1/raw_items
+```
+
+##### Successful Response
+
+```http
+HTTP/1.1 200 OK
+```
+
+###### Body
+
+<details><summary>Example Body</summary>
+
+```json
+{
+    "data": [
+        {
+            "id": "1",
+            "type": "raw_items",
+            "attributes": {
+                "id": 1,
+                "name": "B. F. Sword",
+                "thumbnail": "https://raw.communitydragon.org/latest/game/assets/maps/particles/tft/icon_bfsword.tft.png",
+                "stat_boost": " +20 Attack Damage"
             }
+        },
+        {
+            "id": "2",
+            "type": "raw_items",
+            "attributes": {
+                "id": 2,
+                "name": "Chain Vest",
+                "thumbnail": "https://raw.communitydragon.org/latest/game/assets/maps/particles/tft/tft_item_chainvest.tft.png",
+                "stat_boost": "+20 Armor"
+            }
+        }
+		]
+}
+```
+
+</details>
+
+<details><summary>Failed Responses</summary>
+
+##### Other
+
+```http
+HTTP/1.1 500 Internal Server Error
+```
+
+###### Body
+
+```js
+{"error": "Internal Server Error"}
+```
+
+</details>
+
+---
+
+#### Raw Item Show
+
+Returns a raw_item along with their origin_class_type information.
+
+##### Request
+
+```http
+GET /api/v1/raw_items/:id
+```
+
+##### Successful Response
+
+```http
+HTTP/1.1 200 OK
+```
+
+###### Body
+
+<details><summary>Example Body</summary>
+
+```json
+{
+    "data": {
+        "id": "1",
+        "type": "raw_items",
+        "attributes": {
+            "id": 1,
+            "name": "B. F. Sword",
+            "thumbnail": "https://raw.communitydragon.org/latest/game/assets/maps/particles/tft/icon_bfsword.tft.png",
+            "stat_boost": " +20 Attack Damage"
         }
     }
 }

--- a/app/controllers/api/v1/raw_items_controller.rb
+++ b/app/controllers/api/v1/raw_items_controller.rb
@@ -1,0 +1,11 @@
+class Api::V1::RawItemsController < ApplicationController
+
+  def index
+    render json: RawItemsSerializer.new(RawItem.all)
+  end
+
+  def show
+    render json: RawItemsSerializer.new(RawItem.find(params[:id]))
+  end
+  
+end

--- a/app/serializers/champions_serializer.rb
+++ b/app/serializers/champions_serializer.rb
@@ -1,16 +1,18 @@
 class ChampionsSerializer
   include FastJsonapi::ObjectSerializer
-
-  attribute :data do |object|
-    object.attributes.symbolize_keys
-  end
-
-
-  attribute :origin_class_type do |object|
-    OriginClassTypeSerializer.new(object.origin_class_types)
-    end
-
-
-
-
+  attributes :id,
+             :name,
+             :champion_thumbnail,
+             :cost,
+             :health,
+             :dmg,
+             :armor,
+             :mr,
+             :atk_spd,
+             :range,
+             :ability_thumbnail,
+             :ability_name,
+             :ability_info,
+             :model_img,
+             :origin_class_types
 end

--- a/app/serializers/origin_class_type_serializer.rb
+++ b/app/serializers/origin_class_type_serializer.rb
@@ -1,10 +1,8 @@
 class OriginClassTypeSerializer
   include FastJsonapi::ObjectSerializer
-
-  attribute :data do |object|
-    object.attributes.symbolize_keys
-  end
-
-
-
+  attributes :name,
+             :thumbnail,
+             :summary,
+             :tier_info,
+             :tiers
 end

--- a/app/serializers/raw_items_serializer.rb
+++ b/app/serializers/raw_items_serializer.rb
@@ -1,0 +1,7 @@
+class RawItemsSerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id,
+             :name,
+             :thumbnail,
+             :stat_boost
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api do
     namespace :v1 do
-      resources :champions, only: [:show,:index]
+      resources :champions, only: [:show, :index]
       resources :origin_class_type, only: [:show, :index]
+      resources :raw_items, only: [:show, :index]
     end
   end
 

--- a/spec/requests/api/v1/raw_items/index_request_spec.rb
+++ b/spec/requests/api/v1/raw_items/index_request_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'Raw Items API' do
+  it 'sends a list of raw_items json' do
+    create_list(:raw_item, 7)
+
+    get '/api/v1/raw_items'
+
+    expect(response).to be_successful
+
+    raw_items = JSON.parse(response.body)
+
+    expect(raw_items['data'].count).to eq(7)
+  end
+
+  it 'in the lis aof JSON object i see each objects attributes' do
+    list = create_list(:raw_item, 7)
+
+    get '/api/v1/raw_items'
+
+    expect(response).to be_successful
+
+    raw_item_attributes = JSON.parse(response.body)['data'][0]['attributes']
+
+    expect(raw_item_attributes['id']).to eq(list[0].id)
+    expect(raw_item_attributes['name']).to eq(list[0].name)
+    expect(raw_item_attributes['thumbnail']).to eq(list[0].thumbnail)
+    expect(raw_item_attributes['stat_boost']).to eq(list[0].stat_boost)
+  end
+end

--- a/spec/requests/api/v1/raw_items/show_request_spec.rb
+++ b/spec/requests/api/v1/raw_items/show_request_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe 'Raw Items API' do\
+  it 'returns one raw_item object' do
+    raw_item = create(:raw_item)
+    raw_item1 = create(:raw_item)
+
+    get "/api/v1/raw_items/#{raw_item.id}"
+
+    expect(response).to be_successful
+
+    raw_item_attributes = JSON.parse(response.body)['data']['attributes']
+
+    expect(raw_item_attributes['id']).to eq(raw_item.id)
+    expect(raw_item_attributes['name']).to eq(raw_item.name)
+    expect(raw_item_attributes['thumbnail']).to eq(raw_item.thumbnail)
+    expect(raw_item_attributes['stat_boost']).to eq(raw_item.stat_boost)
+  end
+end


### PR DESCRIPTION
Closes #9  Raw Item Index
Closes #10 Raw Item Show
Closes #29  JSON Update

```
When a request is made for the raw items
  I receive a List of Raw item objects
  I receive a single Raw item object
```
#### Examples of JSON Changes
<details><summary>Previous Example(Deeply Nested)</summary>

** Removed Items **

```json
{
    "data": {
        "id": "42",
        "type": "champions",
        "attributes": {
          **  "data": { **
                "id": 42,
                "name": "Swain, the Noxian Grand General",
                "champion_thumbnail": "https://ddragon.leagueoflegends.com/cdn/9.14.1/img/champion/Swain.png",
                "cost": 5,
                "health": [
                    850,
                    1530,
                    3060
                ],
                "dmg": 65,
                "armor": 25,
                "mr": 20,
                "atk_spd": 0.65,
                "range": "■■□□",
                "ability_thumbnail": "https://raw.communitydragon.org/latest/game/assets/characters/swain/hud/icons2d/swain_r.png",
                "model_img": "https://i.imgur.com/SNB9NHk.png",
                "created_at": "2019-07-21T04:27:23.072Z",
                "updated_at": "2019-07-21T04:27:23.072Z",
                "ability_name": " Demonflare",
                "ability_info": "Active: Transforms for 6 seconds, dealing 50 / 100 / 150 magic damage to all nearby enemies with each tick while healing for 50 / 90 / 130 health with each tick. At the end of his transformation, sends out a burst of energy dealing 300 / 600 / 900 magic damage to nearby enemies."
            },
            "origin_class_type": {
              **  "data": [ **
                 **   { **
                   **     "id": "9",  **
                    **    "type": "origin_class_type",  **
                    **    "attributes": {   **
                          **  "data": {   **
                                "id": 9,
                                "name": "Shapeshifter",
                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Shapeshifter.png",
                                "summary": "Shapeshifters gain bonus maximum Health when they transform.",
                                "tier_info": [
                                    " (3)  Shapeshifters gain 100% Bonus Maximum Health"
                                ],
                                "tiers": [
                                    3
                                ],
                                "created_at": "2019-07-21T04:27:22.528Z",
                                "updated_at": "2019-07-21T04:27:22.528Z"
                            }
                        }
                    },
                    {
                      **  "id": "11", **
                       ** "type": "origin_class_type",  **
                     **   "attributes": { .  **
                       **     "data": { . **
                                "id": 11,
                                "name": "Demon",
                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Demon.png",
                                "summary": "Attacks from Demons have a chance on hit to burn all of an enemy's mana and deal that much as true damage.",
                                "tier_info": [
                                    " (2)  Demons have a 40% Chance on Hit to Mana Burn",
                                    " (4)  Demons have a 60% Chance on Hit to Mana Burn",
                                    " (6)  Demons have a 80% Chance on Hit to Mana Burn"
                                ],
                                "tiers": [
                                    2,
                                    4,
                                    6
                                ],
                                "created_at": "2019-07-21T04:27:22.535Z",
                                "updated_at": "2019-07-21T04:27:22.535Z"
                            }
                        }
                    },
                    {
                     **   "id": "16", **
                     **   "type": "origin_class_type", **
                       ** "attributes": { . **
                         **   "data": { . **
                                "id": 16,
                                "name": "Imperial",
                                "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Imperial.png",
                                "summary": "Imperials deal double damage.",
                                "tier_info": [
                                    " (2)  1 Random Imperial deals double damage",
                                    " (4)  All Imperials deal double damage"
                                ],
                                "tiers": [
                                    2,
                                    4
                                ],
                                "created_at": "2019-07-21T04:27:22.565Z",
                                "updated_at": "2019-07-21T04:27:22.565Z"
                            }
                        }
                    }
                ]
            }
        }
    }
}
```
</details>

<details><summary>New Example</summary>

```json
{
    "data": {
        "id": "42",
        "type": "champions",
        "attributes": {
            "id": 42,
            "name": "Swain, the Noxian Grand General",
            "champion_thumbnail": "https://ddragon.leagueoflegends.com/cdn/9.13.1/img/champion/Swain.png",
            "cost": 5,
            "health": [
                850,
                1530,
                3060
            ],
            "dmg": 65,
            "armor": 25,
            "mr": 20,
            "atk_spd": 0.65,
            "range": "■■□□",
            "ability_thumbnail": "https://raw.communitydragon.org/latest/game/assets/characters/swain/hud/icons2d/swain_r.png",
            "ability_info": {
                "title": "Demonflare",
                "attributes": [
                    {
                        "healpertick": [
                            50,
                            90,
                            130
                        ],
                        "damagepertick": [
                            50,
                            100,
                            150
                        ],
                        "soulflaredamage": [
                            300,
                            600,
                            900
                        ],
                        "transformduration": 6
                    }
                ],
                "descrption": "Swain transforms, draining health from all nearby enemies. At the end of his transformation, Swain sends out a burst of energy dealing damage to nearby enemies"
            },
            "model_img": "https://i.imgur.com/c7azvHE.png",
            "origin_class_types": [
                {
                    "id": 9,
                    "name": "Shapeshifter",
                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Shapeshifter.png",
                    "summary": "Shapeshifters gain bonus maximum Health when they transform.",
                    "tier_info": [
                        " (3)  Shapeshifters gain 100% Bonus Maximum Health"
                    ],
                    "tiers": [
                        3
                    ],
                    "created_at": "2019-07-19T20:04:15.774Z",
                    "updated_at": "2019-07-19T20:04:15.774Z"
                },
                {
                    "id": 11,
                    "name": "Demon",
                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Demon.png",
                    "summary": "Attacks from Demons have a chance on hit to burn all of an enemy's mana and deal that much as true damage.",
                    "tier_info": [
                        " (2)  Demons have a 40% Chance on Hit to Mana Burn",
                        " (4)  Demons have a 60% Chance on Hit to Mana Burn",
                        " (6)  Demons have a 80% Chance on Hit to Mana Burn"
                    ],
                    "tiers": [
                        2,
                        4,
                        6
                    ],
                    "created_at": "2019-07-19T20:04:15.788Z",
                    "updated_at": "2019-07-19T20:04:15.788Z"
                },
                {
                    "id": 16,
                    "name": "Imperial",
                    "thumbnail": "https://img.rankedboost.com/wp-content/plugins/league/assets/tft/Imperial.png",
                    "summary": "Imperials deal double damage.",
                    "tier_info": [
                        " (2)  1 Random Imperial deals double damage",
                        " (4)  All Imperials deal double damage"
                    ],
                    "tiers": [
                        2,
                        4
                    ],
                    "created_at": "2019-07-19T20:04:15.805Z",
                    "updated_at": "2019-07-19T20:04:15.805Z"
                }
            ]
        }
    }
}
```
</details>

#### Required Steps
- [x] Wrote Tests
- [x] Implemented
- [x] Self-Reviewed

#### Neccesary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

#### Type of change
- [x] New feature
- [] Bug Fix

#### Check the applicable boxes
- [x] This broke nothing BackEnd
- [] This broke some stuff
- [x] This broke everything Frontend

The frontend will need to **Remove All but first data keys**

#### Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)
__Notes:__

#### Checklist:
- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code
